### PR TITLE
docs: clarify API base path and Swagger UI availability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,20 @@ $ sdk install maven
 $ ./mvnw test
 
 # Run application using Maven
-./mvnw spring-boot:run
+$ ./mvnw spring-boot:run
+
+# Run application with the "local" profile (enables Swagger UI)
+$ ./mvnw spring-boot:run -Dspring-boot.run.profiles=local
 ```
 
-* Application: http://localhost:8080
+All REST endpoints are exposed under the `/api` base path.
+
+* REST API: http://localhost:8080/api (e.g. http://localhost:8080/api/posts)
 * Swagger UI: http://localhost:8080/swagger-ui/index.html
+
+> **Note**: Swagger UI is disabled by default (`springdoc.swagger-ui.enabled=false`).
+> It is only available when running with the `local` profile,
+> which enables it via `application-local.properties`.
 
 ## Generating certs
 


### PR DESCRIPTION
  ## What

  Updates the **How to?** section of the README so it matches the actual application
  behaviour.

  ## Why

  - The README pointed to `http://localhost:8080` as the application URL, but all REST
    endpoints are mapped under the `/api` base path (e.g. `/api/posts`).
  - It linked to Swagger UI without mentioning that `springdoc.swagger-ui.enabled=false`
    in the default `application.properties` — the UI is only available when running with
    the `local` profile, which enables it via `application-local.properties`.

  ## Changes

  - Document the `/api` base path with an example endpoint.
  - Add the Maven command to run with the `local` profile.
  - Add a note explaining when Swagger UI is available.

