### PR TITLE
update axelix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.axelixlabs</groupId>
             <artifactId>axelix-spring-boot-4-starter</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3</version>
         </dependency>
 
         <!-- Dev dependencies -->


### PR DESCRIPTION
Hello!  @sivaprasadreddy 
We bumped the Axelix starter version and verified it against Axelix Master 1.0.3. For local runs, please use the Master build from our release [link](https://github.com/axelixlabs/axelix/releases). Feel free to close this PR and apply the changes yourself. Thanks!

Before running, please rebuild the project with `mvn package` so our build plugin runs and generates the required project info.
